### PR TITLE
Refactor page metadata input styling

### DIFF
--- a/src/app/app/[[...slug]]/_page/editor/page-metadata.tsx
+++ b/src/app/app/[[...slug]]/_page/editor/page-metadata.tsx
@@ -34,7 +34,7 @@ const PageMetadata = ({ pageTitle, pageId, emoji: savedEmoji }: Props) => {
           type="text"
           placeholder="Untitled Document"
           defaultValue={title}
-          className="text-4xl font-bold outline-none"
+          className="bg-background-dark text-4xl font-bold outline-none"
           onBlur={handleTitleChange}
         />
       </div>


### PR DESCRIPTION
This pull request refactors the styling of the page metadata input component. The `className` of the input element has been updated to include the `bg-background-dark` class, which changes the background color of the input field.