### PR TITLE
Development

### DIFF
--- a/# Observations.md
+++ b/# Observations.md
@@ -1,0 +1,3 @@
+# Observations
+
+- In incognito mode, the browser does not store cookies, browsing history, or any other data. This is useful for browsing privately. Also, localstorage and sessionstorage are not available in incognito mode per my tests.

--- a/src/app/app/_components/sidebar/user-profile-dropdown-menu.tsx
+++ b/src/app/app/_components/sidebar/user-profile-dropdown-menu.tsx
@@ -27,9 +27,11 @@ import { useUser } from "@/features/auth/api/users";
 import { useWorkspace } from "@/features/workspaces/hooks/use-workspace";
 import { toast } from "sonner";
 import { WorkspaceSelector } from "./workspace-selector";
+import { useWorkspaceStore } from "@/features/workspaces/store/workspace-store";
 
 export function UserProfileMenu() {
   const { signOut } = useAuthActions();
+  const { setCurrentWorkspaceId } = useWorkspaceStore();
   const { user, isLoading } = useUser();
   const router = useRouter();
   const { getWorkspaces } = useWorkspace();
@@ -46,7 +48,7 @@ export function UserProfileMenu() {
         <Button
           variant="ghost"
           size={"sm"}
-          className="hover:bg-background-lighter flex flex-1 items-center justify-start space-x-2 truncate pr-0"
+          className="flex flex-1 items-center justify-start space-x-2 truncate pr-0 hover:bg-background-lighter"
         >
           <Skeleton className="h-6 w-6 rounded-lg" />
           <Skeleton className="h-6 w-full" />
@@ -58,7 +60,7 @@ export function UserProfileMenu() {
               <Button
                 variant="ghost"
                 size={"sm"}
-                className="hover:bg-background-lighter flex flex-1 items-center justify-start space-x-2 truncate pr-0"
+                className="flex flex-1 items-center justify-start space-x-2 truncate pr-0 hover:bg-background-lighter"
               >
                 <Avatar className="h-6 w-6 rounded-lg">
                   <AvatarImage src={user.image} />
@@ -82,7 +84,12 @@ export function UserProfileMenu() {
                         <PlusSquareIcon className="mr-2 h-4 w-4" />
                         <span>Join or create workspace</span>
                       </DropdownMenuItem>
-                      <DropdownMenuItem onClick={async () => await signOut()}>
+                      <DropdownMenuItem
+                        onClick={async () => {
+                          await signOut();
+                          setCurrentWorkspaceId(undefined);
+                        }}
+                      >
                         <XCircle className="mr-2 h-4 w-4" />
                         <span>Log out</span>
                       </DropdownMenuItem>

--- a/src/features/workspaces/store/workspace-store.ts
+++ b/src/features/workspaces/store/workspace-store.ts
@@ -4,7 +4,7 @@ import { createJSONStorage, persist, StateStorage } from "zustand/middleware";
 
 type WorkspaceStore = {
   workspaceId: Id<"workspaces"> | undefined;
-  setCurrentWorkspaceId: (workspace: Id<"workspaces">) => void;
+  setCurrentWorkspaceId: (workspace: Id<"workspaces"> | undefined) => void;
 };
 
 const storage: StateStorage = {


### PR DESCRIPTION
This commit refactors the UserProfileMenu component in the sidebar to use the useWorkspaceStore hook. The useWorkspaceStore hook is imported from "@/features/workspaces/store/workspace-store". The setCurrentWorkspaceId function is now called with an undefined value after signing out. This change improves the code structure and ensures that the current workspace ID is cleared when signing out.

Refactor: src/app/app/_components/sidebar/user-profile-dropdown-menu.tsx
Update: src/features/workspaces/store/workspace-store.ts